### PR TITLE
Fix for usage counter not properly updating when Bank window is not open and improvement for detection of filled pouches to properly allocate usage across multiple pouches when filled on the same tick

### DIFF
--- a/src/main/java/com/example/PouchUsageLeft.java
+++ b/src/main/java/com/example/PouchUsageLeft.java
@@ -3,7 +3,6 @@ package com.example;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Multisets;
-import com.google.inject.Provides;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
@@ -13,7 +12,6 @@ import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.widgets.WidgetInfo;
-import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
@@ -22,18 +20,19 @@ import net.runelite.client.ui.overlay.OverlayManager;
 
 import javax.inject.Inject;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
 @PluginDescriptor(
-	name = "Runecrafting counter"
+		name = "Runecrafting counter"
 )
 public class PouchUsageLeft extends Plugin
 {
 	private static final int SPELL_CONTACT_ANIMATION_ID = 4413;
 
-	private static final int[] AREAS_CLOSE_TO_ZMI = {9778, 12119};
+	private static final int SMALL_POUCH = ItemID.SMALL_POUCH;
 	private static final int MED_POUCH = ItemID.MEDIUM_POUCH;
 	private static final int LARGE_POUCH = ItemID.LARGE_POUCH;
 	private static final int GIANT_POUCH = ItemID.GIANT_POUCH;
@@ -46,24 +45,34 @@ public class PouchUsageLeft extends Plugin
 
 	@Getter
 	private Map<Integer, Integer> itemUses = new HashMap<Integer, Integer>() {{
-			put(MED_POUCH, 0);
-			put(LARGE_POUCH, 0);
-			put(GIANT_POUCH, 0);
-			put(COLOSSAL_POUCH, 0);
+		put(SMALL_POUCH, 0);
+		put(MED_POUCH, 0);
+		put(LARGE_POUCH, 0);
+		put(GIANT_POUCH, 0);
+		put(COLOSSAL_POUCH, 0);
 	}};
 
 	public final Map<Integer, Integer> maxItemUses = new HashMap<Integer, Integer>() {{
+		put(SMALL_POUCH, -1);
 		put(MED_POUCH, MED_POUCH_USES);
 		put(LARGE_POUCH, LARGE_POUCH_USES);
 		put(GIANT_POUCH, GIANT_POUCH_USES);
 		put(COLOSSAL_POUCH, COLOSSAL_POUCH_USES);
 	}};
 
+	public final Map<Integer, Integer> pouchSize = new HashMap<Integer, Integer>() {{
+		put(SMALL_POUCH, 3);
+		put(MED_POUCH, 6);
+		put(LARGE_POUCH, 9);
+		put(GIANT_POUCH, 12);
+		put(COLOSSAL_POUCH, 40);
+	}};
+
+	//Ordered list of which pouches were filled on a tick to deduct from max capacity
+	public ArrayList<Integer> filledPouches = new ArrayList<Integer>();
+
 	private Multiset<Integer> previousInventorySnapshot;
 	private int lastClickedItem = -1;
-
-	@Getter
-	private boolean isClose = false;
 
 	@Inject
 	private Client client;
@@ -81,7 +90,8 @@ public class PouchUsageLeft extends Plugin
 	}
 
 	@Override
-	protected void shutDown() throws Exception {
+	protected void shutDown() throws Exception
+	{
 		overlayManager.remove(rcOverlay);
 	}
 
@@ -96,38 +106,17 @@ public class PouchUsageLeft extends Plugin
 		String playerName = client.getLocalPlayer().getName();
 		String actorName = event.getActor().getName();
 
-		if (!playerName.equals(actorName)) {
+		if (!playerName.equals(actorName))
+		{
 			return;
 		}
 
 		int animId = event.getActor().getAnimation();
-		if (animId == SPELL_CONTACT_ANIMATION_ID) {
+		if (animId == SPELL_CONTACT_ANIMATION_ID)
+		{
 			itemUses.replaceAll((k, v) -> 0);
 		}
 
-	}
-
-	@Subscribe
-	public void onGameTick(GameTick tick) {
-
-		isClose = isCloseToZMI();
-	}
-
-	private boolean isCloseToZMI()
-	{
-		Player local = client.getLocalPlayer();
-		if (local == null)
-		{
-			return false;
-		}
-
-		WorldPoint location = local.getWorldLocation();
-		//log.info("RegionID: {}", location.getRegionID());
-		for (int area : AREAS_CLOSE_TO_ZMI) {
-			if (location.getRegionID() == area)
-				return true;
-		}
-		return false;
 	}
 
 	private Multiset<Integer> getInventorySnapshot()
@@ -143,6 +132,7 @@ public class PouchUsageLeft extends Plugin
 
 		return inventorySnapshot;
 	}
+
 	@Subscribe
 	public void onItemContainerChanged(ItemContainerChanged event)
 	{
@@ -151,15 +141,31 @@ public class PouchUsageLeft extends Plugin
 		if (lastClickedItem == -1) return;
 		Multiset<Integer> currentInventorySnapshot = getInventorySnapshot();
 		final Multiset<Integer> itemsRemoved = Multisets.difference(previousInventorySnapshot, currentInventorySnapshot);
-		if (itemsRemoved.isEmpty()){
+		if (itemsRemoved.isEmpty())
+		{
 			log.info("Did not actually fill anything...");
 			return;
 		}
 
-
-		int removedItemCount = (int)itemsRemoved.stream().filter(k -> k == ItemID.DAEYALT_ESSENCE || k == ItemID.PURE_ESSENCE || k == ItemID.GUARDIAN_ESSENCE).count();
+		int removedItemCount = (int)itemsRemoved.stream().filter(k -> k == ItemID.DAEYALT_ESSENCE || k == ItemID.PURE_ESSENCE || k == ItemID.RUNE_ESSENCE || k == ItemID.GUARDIAN_ESSENCE).count();
 		log.info("Stored {} items", removedItemCount);
-		itemUses.put(lastClickedItem, itemUses.get(lastClickedItem)+removedItemCount);
+
+		//Iterate over pouches filled in a single tick in order they were clicked, incrementing respective pouch usage by at most the maximum capacity of each pouch; Break loop when all essence stored on the tick has been accounted for
+		//This is still a bit buggy and doesn't always like updating each pouch correctly if pouches are clicked on rapidly, but it's an improvement over taking the total stored essence amount out of only the last pouch clicked when filling multiple pouches simultaneously
+		for (int i = 0; i < filledPouches.size(); i++)
+		{
+			int pouchID = filledPouches.get(i);
+			itemUses.put(pouchID, itemUses.get(pouchID) + Math.min(removedItemCount, pouchSize.get(pouchID)));
+			if (removedItemCount <= pouchSize.get(pouchID))
+			{
+				break;
+			}
+			else
+			{
+				removedItemCount = removedItemCount - pouchSize.get(pouchID);
+			}
+		}
+		filledPouches.clear();
 		lastClickedItem = -1;
 	}
 
@@ -170,20 +176,21 @@ public class PouchUsageLeft extends Plugin
 		if (event.getMenuOption() == null || !event.getMenuOption().equals("Fill")) {
 			return;
 		}
-		int inventoryIndex = event.getActionParam();
+
+		//get inventory index of Essence Pouch being filled
+		int inventoryIndex = event.getParam0();
 		final int itemId;
 		final String itemName;
 
-		if (event.getWidgetId() == WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER.getId()) {
-			ItemContainer inventoryContainer = client.getItemContainer(InventoryID.INVENTORY);
-			Item item = inventoryContainer.getItem(inventoryIndex);
-			itemId = item.getId();
-			itemName = item.toString();
-		} else {
-			final ItemComposition itemComposition = itemManager.getItemComposition(event.getId());
-			itemId = itemComposition.getId();
-			itemName = itemComposition.getName();
+		ItemContainer inventoryContainer = client.getItemContainer(InventoryID.INVENTORY);
+		Item item = inventoryContainer.getItem(inventoryIndex);
+		itemId = item.getId();
+		itemName = item.toString();
+		if(!filledPouches.contains(itemId))
+		{
+			filledPouches.add(itemId);
 		}
+		log.info("Filled pouches: {}", filledPouches);
 
 		if (!itemUses.containsKey(itemId)) {
 			log.info("Filled an item that we don't know about: {} with ID: {}", itemName, itemId);

--- a/src/main/java/com/example/RCPouchOverlay.java
+++ b/src/main/java/com/example/RCPouchOverlay.java
@@ -59,8 +59,11 @@ class RCPouchOverlay extends WidgetItemOverlay
             textComponent.setColor(Color.RED);
         }
 
-        textComponent.setText(Integer.toString(usesLeft));
+        //Prevent rendering of usage counter on Small Pouch
+        if (usesLeft > 0) {
+            textComponent.setText(Integer.toString(usesLeft));
 
-        textComponent.render(graphics);
+            textComponent.render(graphics);
+        }
     }
 }


### PR DESCRIPTION
Fixed counter not working when Bank window is not open;
Improved onItemContainerChanged to prevent filling multiple pouches simultaneously from being treated as only filling the last-clicked pouch with the total stored essence;
Removed ZMI-related stuff since plugin should not be dependent on being near ZMI now